### PR TITLE
PHP CS Fixer: Import global namespace classes

### DIFF
--- a/PhpCsFixer/Psr12DefaultRules.php
+++ b/PhpCsFixer/Psr12DefaultRules.php
@@ -35,6 +35,11 @@ return [
         ],
     ],
     'concat_space' => ['spacing' => 'one'],
+    'global_namespace_import' => [
+        'import_classes' => true,
+        'import_constants' => false,
+        'import_functions' => false
+    ],
     'increment_style' => ['style' => 'post'],
     'multiline_whitespace_before_semicolons' => ['strategy' => 'no_multi_line'],
     'native_constant_invocation' => false,


### PR DESCRIPTION
Enable global_namespace_import rule with setting
import_classes set to true for consistent import
of classes from the global namespace.